### PR TITLE
Quickfix launch file

### DIFF
--- a/launch/dynamixel_control.launch
+++ b/launch/dynamixel_control.launch
@@ -1,7 +1,7 @@
 <launch>
   <node pkg="dynamixel_control" type="dynamixel_control" name="dynamixel_control" output="screen">
     <param name="port_name" value="/dev/ttyUSB0"/>
-    <!--<param name="baudrate" value="4098"/> <!--115 200 Baud-->
+    <!--<param name="baudrate" value="4098"/> 115 200 Baud-->
     <param name="baudrate" value="4104"/> <!--1 M Baud-->
   </node>
 </launch>


### PR DESCRIPTION
The launch file for dynamixel_control had a typo in a comment that made roslaunch crash.
